### PR TITLE
Added ability to adjust iframe padding back into embed widget.

### DIFF
--- a/api/embed.js
+++ b/api/embed.js
@@ -19,6 +19,7 @@
          parent_url: d.getAttribute("data-parent_url"),
          border: d.getAttribute("data-border"),
          border_radius: d.getAttribute("data-border_radius"),
+         padding: d.getAttribute("data-padding"),
          height: d.getAttribute("data-height"),
          demo: d.getAttribute("data-demo"),
 


### PR DESCRIPTION
There were refeneces to it in code, but seemed to not be taking this from iframe data props.

This is the commit is was added on, and no changes related to "padding" in that file since:
@9c92c20