### PR TITLE
Dockerize dgps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+*~
+*#
+env_dev
+
+
 node_modules
 bower_components
 public

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,51 @@
-FROM node:10.15.0
+FROM node:6.2.0
 
-RUN npm install -g gulp
-RUN npm install -g bower
-RUN npm install gulp
-RUN npm link gulp
+# sudo docker image build -t polis-client-participation:1.0 .
+# sudo docker container run --network="host" --publish 5000:5000 --detach --name polis-client-participation polis-client-participation:1.0
+# sudo docker container kill polis-client-participation
+# sudo docker container rm polis-client-participation
+# sudo docker logs polis-client-participation
+# --network="host" 
 
-COPY package*.json ./
-COPY bower.json ./
-RUN npm install
-RUN bower install --allow-root
+# sudo docker container kill polis-client-participation; sudo docker container rm polis-client-participation; sudo docker image build -t polis-client-participation:1.0 .
+# sudo docker container run --network="host" --publish 5000:5000 --detach --name polis-client-participation polis-client-participation:1.0
 
-ADD polis.config.template.js polis.config.js
 
-ADD . .
+ARG host=localhost
+ARG port=5001
 
-RUN gulp prodBuildNoDeploy
+ARG static_files_host=localhost
+ARG static_files_port=5001
+
+ARG static_files_admin_host=localhost
+ARG static_files_admin_port=5002
+
+ARG postgres_host=localhost
+ARG postgres_port=5432
+ARG postgres_uid=postgres
+ARG postgres_pwd=postgres
+ARG postgres_db=polis-dev
+
+ENV DOMAIN_OVERRIDE ${host}:${port}
+ENV PORT ${port}
+
+ENV STATIC_FILES_HOST ${static_files_host}
+ENV STATIC_FILES_PORT ${static_files_port}
+ENV STATIC_FILES_ADMINDASH_PORT ${static_files_admin_port}
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install -g gulp && \
+    npm install -g bower && \
+    npm install && \
+    bower install --allow-root
+
+EXPOSE ${port}
+
+#CMD npm start
+
+CMD [ "node", "gulpfile.js", "default" ]
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,8 @@ EXPOSE ${port}
 
 # CMD npm start
 
-#CMD [ "node", "gulpfile.js", "default" ]
+CMD [ "node", "gulpfile.js", "default" ]
 
-CMD [ "node" "./node_modules/.bin/grunt" ]
+#CMD [ "node", "./node_modules/.bin/grunt" ]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ COPY . .
 
 EXPOSE ${port}
 
-#CMD npm start
+# CMD npm start
 
-CMD [ "node", "gulpfile.js", "default" ]
+#CMD [ "node", "gulpfile.js", "default" ]
+
+CMD [ "node" "./node_modules/.bin/grunt" ]
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,15 @@
 FROM node:6.2.0
 
-# sudo docker image build -t polis-client-participation:1.0 .
-# sudo docker container run --network="host" --publish 5000:5000 --detach --name polis-client-participation polis-client-participation:1.0
-# sudo docker container kill polis-client-participation
-# sudo docker container rm polis-client-participation
-# sudo docker logs polis-client-participation
-# --network="host" 
-
-# sudo docker container kill polis-client-participation; sudo docker container rm polis-client-participation; sudo docker image build -t polis-client-participation:1.0 .
-# sudo docker container run --network="host" --publish 5000:5000 --detach --name polis-client-participation polis-client-participation:1.0
-
-
-ARG host=localhost
-ARG port=5001
-
-ARG static_files_host=localhost
-ARG static_files_port=5001
-
-ARG static_files_admin_host=localhost
-ARG static_files_admin_port=5002
-
-ARG postgres_host=localhost
-ARG postgres_port=5432
-ARG postgres_uid=postgres
-ARG postgres_pwd=postgres
-ARG postgres_db=polis-dev
-
-ENV DOMAIN_OVERRIDE ${host}:${port}
-ENV PORT ${port}
-
-ENV STATIC_FILES_HOST ${static_files_host}
-ENV STATIC_FILES_PORT ${static_files_port}
-ENV STATIC_FILES_ADMINDASH_PORT ${static_files_admin_port}
-
 WORKDIR /app
 
-COPY . .
+COPY *.json ./
 
 RUN npm install -g gulp && \
     npm install -g bower && \
     npm install && \
     bower install --allow-root
+
+COPY . .
 
 EXPOSE ${port}
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,8 +3,8 @@
 module.exports = function(grunt) {
   grunt.option('stack', true);
 
-  var port = process.env.PORT || 8000,
-      hostname = 'localhost',
+  var port = process.env.STATIC_FILES_PORT || 8000,
+      hostname = process.env.STATIC_FILES_HOST || 'localhost',
       templates = {},
       paths = {
         'public': 'public',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -189,7 +189,7 @@ gulp.task('connect', [], function() {
 
 
   app.listen(polisConfig.PORT);
-  console.log('listening on localhost:' + polisConfig.PORT);
+  console.log('Listening at http://localhost:' + polisConfig.PORT);
 });
 
 function getGitHash() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -187,9 +187,14 @@ gulp.task('connect', [], function() {
   app.use(/^\/wimp$/, express.static(path.join(destRootBase, "wimp.html")));
   app.use(/^\/try$/, express.static(path.join(destRootBase, "try.html")));
 
+  app.listen(polisConfig.CLIENT_PORT, polisConfig.CLIENT_HOST, function(err) {
+  if (err) {
+    console.log("error", err);
+    return;
+  }
 
-  app.listen(polisConfig.PORT);
-  console.log('Listening at http://localhost:' + polisConfig.PORT);
+  console.log('Listening at http://'+polisConfig.CLIENT_HOST+':'+polisConfig.CLIENT_PORT);
+
 });
 
 function getGitHash() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -186,15 +186,8 @@ gulp.task('connect', [], function() {
   app.use(/^\/billions$/, express.static(path.join(destRootBase, "billions.html")));
   app.use(/^\/wimp$/, express.static(path.join(destRootBase, "wimp.html")));
   app.use(/^\/try$/, express.static(path.join(destRootBase, "try.html")));
-
-  app.listen(polisConfig.CLIENT_PORT, polisConfig.CLIENT_HOST, function(err) {
-  if (err) {
-    console.log("error", err);
-    return;
-  }
-
+  app.listen(polisConfig.CLIENT_PORT, polisConfig.CLIENT_HOST);
   console.log('Listening at http://'+polisConfig.CLIENT_HOST+':'+polisConfig.CLIENT_PORT);
-
 });
 
 function getGitHash() {


### PR DESCRIPTION
This is the third of 4 pull requests to enable pol-is to run in dev mode using docker-compose. To see all 4 pull requests working together, please follow the instructions at https://github.com/pol-is/polis-issues/issues/125. 

1.	This request changes the `Dockerfile` to run in dev mode instead of production mode. For people getting started with pol-is, this might be a better choice. 
2.	This request makes minor changes to `.gitignore`.
3.	This request reverts to node 6.10.3. node 6.2.0 was not working in dev mode. 
4.	This request modifies ` Gruntfile.js` and ` gulpfile.js` to enable ` polisClientParticipation` to run in a separate container with a unique IP address. 
