### PR TITLE
WIP to hide commenting help text

### DIFF
--- a/js/templates/comment-form.handlebars
+++ b/js/templates/comment-form.handlebars
@@ -22,10 +22,12 @@
     style="{{#unless desktop}}font-size:12px;{{/unless}}"
     >
       {{!-- present all hints to screen reader --}}
-      <label for="comment_form_textarea" style="display:block">
+      <label for="comment_form_textarea"
+             style="display:{{#if hideHelp}}none{{else}}block{{/if}};">
         {{{s.writeCommentHelpText}}}
       </label>
 
+      {{#if hideHelp}}
       <p>
         {{{s.helpWriteListIntro}}}
       </p>
@@ -37,6 +39,8 @@
       <label for="comment_form_textarea" style="display:block">
         {{{s.tipCommentsRandom}}}
       </label>
+      {{/if}}
+
       {{!-- end screen-reader-text --}}
   </p>
 

--- a/js/templates/comment-form.handlebars
+++ b/js/templates/comment-form.handlebars
@@ -22,23 +22,29 @@
     style="{{#unless desktop}}font-size:12px;{{/unless}}"
     >
       {{!-- present all hints to screen reader --}}
-      <label for="comment_form_textarea"
-             style="display:{{#if hideHelp}}none{{else}}block{{/if}};">
-        {{{s.writeCommentHelpText}}}
-      </label>
 
       {{#if hideHelp}}
-      <p>
-        {{{s.helpWriteListIntro}}}
-      </p>
-      <ul>
-        <li>{{{s.helpWriteListStandalone}}}</li>
-        <li>{{{s.helpWriteListRaisNew}}}</li>
-        <li>{{{s.helpWriteListShort}}}</li>
-      </ul>
-      <label for="comment_form_textarea" style="display:block">
-        {{{s.tipCommentsRandom}}}
-      </label>
+        {{!-- even if help text is hidden, still screen read the main comment box label/prompt --}}
+        <label for="comment_form_textarea"
+               style="display:none;">
+          {{{s.writeCommentHelpText}}}
+        </label>
+      {{else}}
+        <label for="comment_form_textarea"
+               style="display:block;">
+          {{{s.writeCommentHelpText}}}
+        </label>
+        <p>
+          {{{s.helpWriteListIntro}}}
+        </p>
+        <ul>
+          <li>{{{s.helpWriteListStandalone}}}</li>
+          <li>{{{s.helpWriteListRaisNew}}}</li>
+          <li>{{{s.helpWriteListShort}}}</li>
+        </ul>
+        <label for="comment_form_textarea" style="display:block">
+          {{{s.tipCommentsRandom}}}
+        </label>
       {{/if}}
 
       {{!-- end screen-reader-text --}}

--- a/js/views/comment-form.js
+++ b/js/views/comment-form.js
@@ -44,6 +44,7 @@ module.exports = Handlebones.ModelView.extend({
     ctx.hasFacebook = userObject.hasFacebook;
     ctx.s = Strings;
     ctx.desktop = !display.xs();
+    ctx.hideHelp = !Utils.userCanSeeHelp() || preload.firstConv.help_type === 0;
 
     ctx.no_write_hint = false; //preload.firstConv.write_hint_type === 0;
 


### PR DESCRIPTION
Not all the way there yet; Still isn't hiding the main `s.writeCommentHelpText` but not sure why. Figure we want to keep that label, but just not display, for screen readers.